### PR TITLE
Add unit test project and tests for BaseService<Contact>

### DIFF
--- a/04_UnitTest/04_UnitTest.csproj
+++ b/04_UnitTest/04_UnitTest.csproj
@@ -1,0 +1,33 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <RootNamespace>UnitTest</RootNamespace>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.0" />
+    <PackageReference Include="FluentAssertions" Version="8.2.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.15" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="Moq" Version="4.20.72" />
+    <PackageReference Include="RichardSzalay.MockHttp" Version="7.0.0" />
+    <PackageReference Include="xunit" Version="2.5.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\01_Core\03_Core.csproj" />
+    <ProjectReference Include="..\02_Application\02_Application.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+</Project>

--- a/04_UnitTest/Configuration/TestService.cs
+++ b/04_UnitTest/Configuration/TestService.cs
@@ -1,0 +1,10 @@
+﻿using Application.Service.Base;
+using Core.Entity;
+
+namespace UnitTest.Configuration
+{
+    public class TestService : BaseService<Contact>
+    {
+        public TestService(HttpClient client, string baseUrl) : base(client, baseUrl) { }
+    }
+}

--- a/04_UnitTest/Repository/ContactRepositoryTests.cs
+++ b/04_UnitTest/Repository/ContactRepositoryTests.cs
@@ -1,0 +1,158 @@
+﻿using Application.Service.Base;
+using Application.ViewModel;
+using Core.Entity;
+using FluentAssertions;
+using RichardSzalay.MockHttp;
+using System.Net;
+using System.Text.Json;
+
+namespace UnitTest.Repository
+{
+    public class ContactRepositoryTests
+    {
+        private const string BaseUrl = "http://fake-api.com";
+
+
+        private class ContactHttpService : BaseService<Contact>
+        {
+            public ContactHttpService(HttpClient client, string baseUrl) : base(client, baseUrl) { }
+        }
+
+        [Fact]
+        public async Task GetByIdAsync_ValidResponse_ReturnsContact()
+        {
+            var contact = new Contact
+            {
+                Id = 1,
+                Name = "Maria",
+                Phone = "99999-0000",
+                Email = "maria@mail.com",
+                DddId = 11
+            };
+
+            var mockHttp = new MockHttpMessageHandler();
+            mockHttp.When($"{BaseUrl}/contacts/1")
+                    .Respond("application/json", JsonSerializer.Serialize(new ApiResponse<Contact> { Data = contact }));
+
+            var service = new ContactHttpService(mockHttp.ToHttpClient(), BaseUrl);
+
+            var result = await service.GetByIdAsync(1);
+
+            result.Should().NotBeNull();
+            result.Id.Should().Be(1);
+            result.Name.Should().Be("Maria");
+        }
+
+        [Fact]
+        public async Task GetByIdAsync_InvalidJson_ThrowsException()
+        {
+            var mockHttp = new MockHttpMessageHandler();
+            mockHttp.When($"{BaseUrl}/contacts/1")
+                    .Respond("application/json", "{}"); // resposta inválida
+
+            var service = new ContactHttpService(mockHttp.ToHttpClient(), BaseUrl);
+
+            Func<Task> act = async () => await service.GetByIdAsync(1);
+            await act.Should().ThrowAsync<Exception>().WithMessage("*resposta inválida*");
+        }
+        [Fact]
+        public async Task GetAllAsync_ValidResponse_ReturnsContacts()
+        {
+            var contacts = new List<Contact>
+        {
+            new() { Id = 1, Name = "A", Phone = "1", Email = "a@mail.com", DddId = 11 },
+            new() { Id = 2, Name = "B", Phone = "2", Email = "b@mail.com", DddId = 11 }
+        };
+
+            var mockHttp = new MockHttpMessageHandler();
+            mockHttp.When($"{BaseUrl}/contacts")
+                    .Respond("application/json", JsonSerializer.Serialize(new ApiResponse<IList<Contact>> { Data = contacts }));
+
+            var service = new ContactHttpService(mockHttp.ToHttpClient(), BaseUrl);
+
+            var result = await service.GetAllAsync();
+
+            result.Should().HaveCount(2);
+            result[0].Name.Should().Be("A");
+        }
+
+        [Fact]
+        public async Task GetAllAsync_NullData_ReturnsEmptyList()
+        {
+            var mockHttp = new MockHttpMessageHandler();
+            mockHttp.When($"{BaseUrl}/contacts")
+                    .Respond("application/json", "{}");
+
+            var service = new ContactHttpService(mockHttp.ToHttpClient(), BaseUrl);
+
+            var result = await service.GetAllAsync();
+
+            result.Should().BeEmpty();
+        }
+
+        [Fact]
+        public async Task CreateAsync_ValidContact_Succeeds()
+        {
+            var contact = new Contact
+            {
+                Name = "Carlos",
+                Phone = "99999-9999",
+                Email = "carlos@mail.com",
+                DddId = 21
+            };
+
+            var mockHttp = new MockHttpMessageHandler();
+            mockHttp.When($"{BaseUrl}/contacts")
+                    .Respond(HttpStatusCode.Created);
+
+            var service = new ContactHttpService(mockHttp.ToHttpClient(), BaseUrl);
+
+            var act = async () => await service.CreateAsync(contact);
+            await act.Should().NotThrowAsync();
+        }
+
+        [Fact]
+        public async Task EditAsync_RequestFails_ThrowsException()
+        {
+            var contact = new Contact
+            {
+                Id = 7,
+                Name = "Edit Fail",
+                Phone = "00000-0000",
+                Email = "fail@mail.com",
+                DddId = 99
+            };
+
+            var mockHttp = new MockHttpMessageHandler();
+            mockHttp.When($"{BaseUrl}/contacts/7")
+                    .Respond(HttpStatusCode.BadRequest);
+
+            var service = new ContactHttpService(mockHttp.ToHttpClient(), BaseUrl);
+
+            Func<Task> act = async () => await service.EditAsync(contact);
+            await act.Should().ThrowAsync<HttpRequestException>();
+        }
+
+        [Fact]
+        public async Task DeleteAsync_SuccessfulDeletion_DoesNotThrow()
+        {
+            var contact = new Contact
+            {
+                Id = 3,
+                Name = "Delete Me",
+                Phone = "00000-1234",
+                Email = "delete@mail.com",
+                DddId = 11
+            };
+
+            var mockHttp = new MockHttpMessageHandler();
+            mockHttp.When($"{BaseUrl}/contacts/3")
+                    .Respond(HttpStatusCode.NoContent);
+
+            var service = new ContactHttpService(mockHttp.ToHttpClient(), BaseUrl);
+
+            var act = async () => await service.DeleteAsync(contact);
+            await act.Should().NotThrowAsync();
+        }
+    }
+}

--- a/techChallegeFase3.sln
+++ b/techChallegeFase3.sln
@@ -9,6 +9,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "03_Core", "01_Core\03_Core.
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "02_Application", "02_Application\02_Application.csproj", "{414A51EF-ADD0-4FAA-AD45-300ABC6E764F}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "04_UnitTest", "04_UnitTest\04_UnitTest.csproj", "{328395E3-3F4C-4BFE-9061-C3F877B7B899}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -27,6 +29,10 @@ Global
 		{414A51EF-ADD0-4FAA-AD45-300ABC6E764F}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{414A51EF-ADD0-4FAA-AD45-300ABC6E764F}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{414A51EF-ADD0-4FAA-AD45-300ABC6E764F}.Release|Any CPU.Build.0 = Release|Any CPU
+		{328395E3-3F4C-4BFE-9061-C3F877B7B899}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{328395E3-3F4C-4BFE-9061-C3F877B7B899}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{328395E3-3F4C-4BFE-9061-C3F877B7B899}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{328395E3-3F4C-4BFE-9061-C3F877B7B899}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
Add unit test project and tests for BaseService<Contact>

Added a new `04_UnitTest` project to the solution, configured as a test project targeting .NET 8.0. Updated the solution file to include build configurations for the new project.

Implemented unit tests in `ContactRepositoryTests` to validate `BaseService<Contact>` functionality, covering scenarios like valid/invalid API responses, error handling, and CRUD operations.

Tests use `MockHttpMessageHandler` for HTTP response simulation and libraries like `xunit`, `FluentAssertions`, and `Moq` for assertions and mocking.